### PR TITLE
Change the class name used for errors

### DIFF
--- a/packages/react-baseline-inputs/src/theme.ts
+++ b/packages/react-baseline-inputs/src/theme.ts
@@ -26,5 +26,5 @@ export const defaultTheme: Theme = {
   labelSmall: "field__label--small",
 
   help: "field__help",
-  error: "message message--problem"
+  error: "field__error"
 };

--- a/packages/react-baseline-inputs/test/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/Checkbox.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Checkbox /> renders with an error 1`] = `
     Jawn
   </label>
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/DateInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<DateInput /> renders with an error 1`] = `
     value="2001-01-01"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/DateTimeInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<DateTimeInput /> renders with an error 1`] = `
     value="2001-01-01T05:00"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/Field.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/Field.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`<Field /> renders with an error 1`] = `
     id="field_4"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/FileInput.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<FileInput /> renders with an error 1`] = `
     type="file"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/FileListInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/FileListInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<FileListInput /> renders with an error 1`] = `
     type="file"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/FloatInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/FloatInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<FloatInput /> renders with an error 1`] = `
     value="5.5"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/IntegerInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/IntegerInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<IntegerInput /> renders with an error 1`] = `
     value="5"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/Select.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`<Select /> renders with an error 1`] = `
     id="field_4"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/TextArea.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<TextArea /> renders with an error 1`] = `
     hello
   </textarea>
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >

--- a/packages/react-baseline-inputs/test/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/TextInput.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<TextInput /> renders with an error 1`] = `
     value="hello"
   />
   <span
-    class="message message--problem"
+    class="field__error"
     id="field_4_error"
     role="alert"
   >


### PR DESCRIPTION
All other classnames start with `field__`, so error should as well.