### PR TITLE
feat: add theme support

### DIFF
--- a/examples/app/src/BaselineInputs.tsx
+++ b/examples/app/src/BaselineInputs.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useForm, initialValues, config, telephoneMask } from "./helpers";
+import { useForm, initialValues, theme, telephoneMask } from "./helpers";
 import {
   Checkbox,
   CheckboxList,
@@ -22,7 +22,7 @@ export const BaselineInputs = () => {
   const [values, fields] = useForm(initialValues);
 
   return (
-    <ThemeProvider value={config}>
+    <ThemeProvider value={theme}>
       <section>
         <h2 className="mb-4">react-baseline-inputs</h2>
 

--- a/examples/app/src/BaselineInputs.tsx
+++ b/examples/app/src/BaselineInputs.tsx
@@ -1,14 +1,5 @@
 import * as React from "react";
-import {
-  useForm,
-  initialValues,
-  theme,
-  fileTheme,
-  selectTheme,
-  checkboxTheme,
-  toggleTheme,
-  telephoneMask
-} from "./helpers";
+import { useForm, initialValues, config, telephoneMask } from "./helpers";
 import {
   Checkbox,
   CheckboxList,
@@ -23,141 +14,121 @@ import {
   RadioGroup,
   Select,
   TextArea,
-  ToggleButton
+  ToggleButton,
+  ThemeProvider
 } from "react-baseline-inputs";
 
 export const BaselineInputs = () => {
   const [values, fields] = useForm(initialValues);
 
   return (
-    <section>
-      <h2 className="mb-4">react-baseline-inputs</h2>
+    <ThemeProvider value={config}>
+      <section>
+        <h2 className="mb-4">react-baseline-inputs</h2>
 
-      <form
-        onSubmit={event => {
-          event.preventDefault();
-          console.table(values);
-        }}
-      >
-        <div className="row">
-          <div className="col">
-            <Input {...fields.text} label="Text" name="text" theme={theme} />
+        <form
+          onSubmit={event => {
+            event.preventDefault();
+            console.table(values);
+          }}
+        >
+          <div className="row">
+            <div className="col">
+              <Input {...fields.text} label="Text" name="text" />
+            </div>
+
+            <div className="col">
+              <IntegerInput label="Integer" {...fields.integer} />
+            </div>
+
+            <div className="col">
+              <FloatInput label="Float" {...fields.float} />
+            </div>
           </div>
+          <div className="row">
+            <div className="col">
+              <DateInput label="Date" {...fields.date} />
+            </div>
 
-          <div className="col">
-            <IntegerInput label="Integer" {...fields.integer} theme={theme} />
-          </div>
+            <div className="col">
+              <DateTimeInput label="DateTime" {...fields.datetime} />
+            </div>
 
-          <div className="col">
-            <FloatInput label="Float" {...fields.float} theme={theme} />
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="col">
-            <DateInput label="Date" {...fields.date} theme={theme} />
-          </div>
-
-          <div className="col">
-            <DateTimeInput
-              label="DateTime"
-              {...fields.datetime}
-              theme={theme}
-            />
-          </div>
-
-          <div className="col">
-            <Select
-              {...fields.select}
-              label="Select"
-              options={["One", "Two", "Three"]}
-              theme={selectTheme}
-            />
-          </div>
-        </div>
-
-        <div className="row mt-2">
-          <div className="col">
-            <MaskedInput
-              label="Masked"
-              {...fields.masked}
-              showMask
-              mask={telephoneMask}
-              theme={theme}
-            />
-          </div>
-
-          <div className="col">
-            <FileInput label="File" {...fields.file} theme={fileTheme} />
-          </div>
-
-          <div className="col">
-            <FileListInput
-              label="FileList"
-              {...fields.filelist}
-              theme={fileTheme}
-            />
-          </div>
-        </div>
-
-        <TextArea label="TextArea" {...fields.textarea} theme={theme} />
-
-        <div className="row mt-2">
-          <div className="col">
-            <Checkbox
-              label="Checkbox"
-              {...fields.checkbox}
-              theme={checkboxTheme}
-            />
-          </div>
-
-          <div className="col">
-            <ToggleButton
-              label="Toggle"
-              {...fields.toggle}
-              theme={toggleTheme}
-            />
-          </div>
-        </div>
-
-        <div className="row mt-4">
-          <div className="col">
-            <fieldset>
-              <legend>Checkbox List</legend>
-              <CheckboxList
-                name="checkboxList"
-                options={[
-                  { label: "Foo", value: "foo" },
-                  { label: "Bar", value: "bar" },
-                  { label: "Disabled", value: "buzz", disabled: true }
-                ]}
-                theme={checkboxTheme}
-                {...fields.checkboxList}
+            <div className="col">
+              <Select
+                {...fields.select}
+                label="Select"
+                options={["One", "Two", "Three"]}
               />
-            </fieldset>
+            </div>
           </div>
-
-          <div className="col">
-            <fieldset>
-              <legend>Radio Group</legend>
-              <RadioGroup
-                name="radioGroup"
-                options={[
-                  { label: "Foo", value: "foo" },
-                  { label: "Bar", value: "bar" },
-                  { label: "Disabled", value: "buzz", disabled: true }
-                ]}
-                theme={checkboxTheme}
-                {...fields.radioGroup}
+          <div className="row mt-2">
+            <div className="col">
+              <MaskedInput
+                label="Masked"
+                {...fields.masked}
+                showMask
+                mask={telephoneMask}
               />
-            </fieldset>
-          </div>
-        </div>
+            </div>
+            <div className="col">
+              <FileInput label="File" {...fields.file} />
+            </div>
 
-        <button type="submit" className="btn btn-primary mt-2 float-right">
-          Submit
-        </button>
-      </form>
-    </section>
+            <div className="col">
+              <FileListInput label="FileList" {...fields.filelist} />
+            </div>
+          </div>
+
+          <TextArea label="TextArea" {...fields.textarea} />
+
+          <div className="row mt-2">
+            <div className="col">
+              <Checkbox label="Checkbox" {...fields.checkbox} />
+            </div>
+
+            <div className="col">
+              <ToggleButton label="Toggle" {...fields.toggle} />
+            </div>
+          </div>
+
+          <div className="row mt-4">
+            <div className="col">
+              <fieldset>
+                <legend>Checkbox List</legend>
+                <CheckboxList
+                  name="checkboxList"
+                  options={[
+                    { label: "Foo", value: "foo" },
+                    { label: "Bar", value: "bar" },
+                    { label: "Disabled", value: "buzz", disabled: true }
+                  ]}
+                  {...fields.checkboxList}
+                />
+              </fieldset>
+            </div>
+
+            <div className="col">
+              <fieldset>
+                <legend>Radio Group</legend>
+                <RadioGroup
+                  name="radioGroup"
+                  options={[
+                    { label: "Foo", value: "foo" },
+                    { label: "Bar", value: "bar" },
+                    { label: "Disabled", value: "buzz", disabled: true }
+                  ]}
+                  {...fields.radioGroup}
+                />
+              </fieldset>
+            </div>
+          </div>
+
+          <button type="submit" className="btn btn-primary mt-2 float-right">
+            Submit
+          </button>
+        </form>
+      </section>
+    </ThemeProvider>
   );
 };

--- a/examples/app/src/BaselineInputs.tsx
+++ b/examples/app/src/BaselineInputs.tsx
@@ -63,7 +63,7 @@ export const BaselineInputs = () => {
             </div>
           </div>
           <div className="row mt-2">
-            <div className="col">
+            <div className="col-4">
               <MaskedInput
                 label="Masked"
                 {...fields.masked}
@@ -71,6 +71,8 @@ export const BaselineInputs = () => {
                 mask={telephoneMask}
               />
             </div>
+          </div>
+          <div className="row mt-3 mb-2">
             <div className="col">
               <FileInput label="File" {...fields.file} />
             </div>

--- a/examples/app/src/FormikInputs.tsx
+++ b/examples/app/src/FormikInputs.tsx
@@ -1,15 +1,6 @@
 import * as React from "react";
 import { Formik, Form } from "formik";
-import {
-  initialValues,
-  theme,
-  fileTheme,
-  selectTheme,
-  checkboxTheme,
-  notBlank,
-  toggleTheme,
-  telephoneMask
-} from "./helpers";
+import { initialValues, config, notBlank, telephoneMask } from "./helpers";
 import {
   Checkbox,
   CheckboxList,
@@ -24,134 +15,120 @@ import {
   RadioGroup,
   Select,
   TextArea,
-  ToggleButton
+  ToggleButton,
+  ThemeProvider
 } from "formik-inputs";
 
 export const FormikInputs = () => {
   return (
-    <section>
-      <h2 className="mb-4">formik-inputs</h2>
+    <ThemeProvider value={config}>
+      <section>
+        <h2 className="mb-4">formik-inputs</h2>
 
-      <Formik
-        initialValues={initialValues}
-        onSubmit={values => console.table(values)}
-      >
-        <Form>
-          <div className="row">
-            <div className="col">
-              <Input
-                name="text"
-                label="Text"
-                theme={theme}
-                validate={notBlank}
-              />
+        <Formik
+          initialValues={initialValues}
+          onSubmit={values => console.table(values)}
+        >
+          <Form>
+            <div className="row">
+              <div className="col">
+                <Input name="text" label="Text" validate={notBlank} />
+              </div>
+
+              <div className="col">
+                <IntegerInput label="Integer" name="integer" />
+              </div>
+
+              <div className="col">
+                <FloatInput label="Float" name="float" />
+              </div>
             </div>
 
-            <div className="col">
-              <IntegerInput label="Integer" name="integer" theme={theme} />
-            </div>
+            <div className="row">
+              <div className="col">
+                <DateInput label="Date" name="date" />
+              </div>
 
-            <div className="col">
-              <FloatInput label="Float" name="float" theme={theme} />
-            </div>
-          </div>
+              <div className="col">
+                <DateTimeInput label="DateTime" name="datetime" />
+              </div>
 
-          <div className="row">
-            <div className="col">
-              <DateInput label="Date" name="date" theme={theme} />
-            </div>
-
-            <div className="col">
-              <DateTimeInput label="DateTime" name="datetime" theme={theme} />
-            </div>
-
-            <div className="col">
-              <Select
-                name="select"
-                label="Select"
-                options={["One", "Two", "Three"]}
-                theme={selectTheme}
-              />
-            </div>
-          </div>
-
-          <div className="row">
-            <div className="col">
-              <MaskedInput
-                label="Masked"
-                name="masked"
-                showMask
-                mask={telephoneMask}
-                theme={theme}
-              />
-            </div>
-
-            <div className="col">
-              <FileInput label="File" name="file" theme={fileTheme} />
-            </div>
-
-            <div className="col">
-              <FileListInput
-                label="FileList"
-                name="filelist"
-                theme={fileTheme}
-              />
-            </div>
-          </div>
-
-          <TextArea label="TextArea" name="textarea" theme={theme} />
-
-          <div className="row mt-2">
-            <div className="col">
-              <Checkbox
-                label="Checkbox"
-                name="checkbox"
-                theme={checkboxTheme}
-              />
-            </div>
-
-            <div className="col">
-              <ToggleButton label="Toggle" name="toggle" theme={toggleTheme} />
-            </div>
-          </div>
-
-          <div className="row mt-4">
-            <div className="col">
-              <fieldset>
-                <legend>Checkbox List</legend>
-                <CheckboxList
-                  name="checkboxList"
-                  options={[
-                    { label: "Foo", value: "foo" },
-                    { label: "Bar", value: "bar" },
-                    { label: "Disabled", value: "buzz", disabled: true }
-                  ]}
-                  theme={checkboxTheme}
+              <div className="col">
+                <Select
+                  name="select"
+                  label="Select"
+                  options={["One", "Two", "Three"]}
                 />
-              </fieldset>
+              </div>
             </div>
 
-            <div className="col">
-              <fieldset>
-                <legend>Checkbox List</legend>
-                <RadioGroup
-                  name="radioGroup"
-                  options={[
-                    { label: "Foo", value: "foo" },
-                    { label: "Bar", value: "bar" },
-                    { label: "Disabled", value: "buzz", disabled: true }
-                  ]}
-                  theme={checkboxTheme}
+            <div className="row mt-2">
+              <div className="col">
+                <MaskedInput
+                  label="Masked"
+                  name="masked"
+                  showMask
+                  mask={telephoneMask}
                 />
-              </fieldset>
-            </div>
-          </div>
+              </div>
 
-          <button type="submit" className="btn btn-primary mt-2 float-right">
-            Submit
-          </button>
-        </Form>
-      </Formik>
-    </section>
+              <div className="col">
+                <FileInput label="File" name="file" />
+              </div>
+
+              <div className="col">
+                <FileListInput label="FileList" name="filelist" />
+              </div>
+            </div>
+
+            <TextArea label="TextArea" name="textarea" />
+
+            <div className="row mt-2">
+              <div className="col">
+                <Checkbox label="Checkbox" name="checkbox" />
+              </div>
+
+              <div className="col">
+                <ToggleButton label="Toggle" name="toggle" />
+              </div>
+            </div>
+
+            <div className="row mt-4">
+              <div className="col">
+                <fieldset>
+                  <legend>Checkbox List</legend>
+                  <CheckboxList
+                    name="checkboxList"
+                    options={[
+                      { label: "Foo", value: "foo" },
+                      { label: "Bar", value: "bar" },
+                      { label: "Disabled", value: "buzz", disabled: true }
+                    ]}
+                  />
+                </fieldset>
+              </div>
+
+              <div className="col">
+                <fieldset>
+                  <legend>Checkbox List</legend>
+                  <RadioGroup
+                    name="radioGroup"
+                    options={[
+                      { label: "Foo", value: "foo" },
+                      { label: "Bar", value: "bar" },
+                      { label: "Disabled", value: "buzz", disabled: true }
+                    ]}
+                  />
+                </fieldset>
+              </div>
+            </div>
+
+            <button type="submit" className="btn btn-primary mt-2 float-right">
+              Submit
+            </button>
+          </Form>
+        </Formik>
+      </section>
+    </ThemeProvider>
   );
 };

--- a/examples/app/src/FormikInputs.tsx
+++ b/examples/app/src/FormikInputs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Formik, Form } from "formik";
-import { initialValues, config, notBlank, telephoneMask } from "./helpers";
+import { initialValues, theme, notBlank, telephoneMask } from "./helpers";
 import {
   Checkbox,
   CheckboxList,
@@ -21,7 +21,7 @@ import {
 
 export const FormikInputs = () => {
   return (
-    <ThemeProvider value={config}>
+    <ThemeProvider value={theme}>
       <section>
         <h2 className="mb-4">formik-inputs</h2>
 

--- a/examples/app/src/FormikInputs.tsx
+++ b/examples/app/src/FormikInputs.tsx
@@ -63,7 +63,7 @@ export const FormikInputs = () => {
             </div>
 
             <div className="row mt-2">
-              <div className="col">
+              <div className="col-4">
                 <MaskedInput
                   label="Masked"
                   name="masked"
@@ -71,7 +71,8 @@ export const FormikInputs = () => {
                   mask={telephoneMask}
                 />
               </div>
-
+            </div>
+            <div className="row mt-3 mb-2">
               <div className="col">
                 <FileInput label="File" name="file" />
               </div>

--- a/examples/app/src/helpers.ts
+++ b/examples/app/src/helpers.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Theme, defaultConfig, defaultTheme } from "react-baseline-inputs";
+import { Theme, defaultFieldTheme, defaultTheme } from "react-baseline-inputs";
 
 export interface Values {
   checkbox: boolean | null;
@@ -67,8 +67,8 @@ export const useForm = <T>(initialValues: T): [T, Fields<T>] => {
   return [values, fields];
 };
 
-export const fieldConfig = {
-  ...defaultTheme,
+export const fieldTheme = {
+  ...defaultFieldTheme,
   field: "form-group",
   input: "form-control",
   inputSuccess: "is-valid",
@@ -79,46 +79,46 @@ export const fieldConfig = {
   help: "form-text text-muted"
 };
 
-export const checkboxConfig = {
-  ...defaultTheme,
+export const checkboxTheme = {
+  ...defaultFieldTheme,
   field: "form-check",
   fieldInline: "form-check-inline",
   input: "form-check-input",
   label: "form-check-label"
 };
 
-export const selectConfig = {
-  ...defaultTheme,
+export const selectTheme = {
+  ...defaultFieldTheme,
   input: "custom-select"
 };
 
-export const fileInputConfig = {
-  ...defaultTheme,
+export const fileInputTheme = {
+  ...defaultFieldTheme,
   field: "custom-file mb-3",
   input: "custom-file-input",
   label: "custom-file-label"
 };
 
-export const toggleButtonConfig = {
-  ...defaultTheme,
+export const toggleButtonTheme = {
+  ...defaultFieldTheme,
   field: "custom-control custom-switch",
   input: "custom-control-input",
   label: "custom-control-label"
 };
 
-export const config = {
-  input: fieldConfig,
-  dateInput: fieldConfig,
-  dateTimeInput: fieldConfig,
-  field: fieldConfig,
-  floatInput: fieldConfig,
-  integerInput: fieldConfig,
-  radioGroup: checkboxConfig,
-  textarea: fieldConfig,
-  select: selectConfig,
-  fileInput: fileInputConfig,
-  checkbox: checkboxConfig,
-  toggleButton: toggleButtonConfig
+export const theme = {
+  input: fieldTheme,
+  dateInput: fieldTheme,
+  dateTimeInput: fieldTheme,
+  field: fieldTheme,
+  floatInput: fieldTheme,
+  integerInput: fieldTheme,
+  radioGroup: checkboxTheme,
+  textarea: fieldTheme,
+  select: selectTheme,
+  fileInput: fileInputTheme,
+  checkbox: checkboxTheme,
+  toggleButton: toggleButtonTheme
 };
 
 export const telephoneMask = [

--- a/examples/app/src/helpers.ts
+++ b/examples/app/src/helpers.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Theme, defaultFieldTheme, defaultTheme } from "react-baseline-inputs";
+import { Theme, FieldTheme } from "react-baseline-inputs";
 
 export interface Values {
   checkbox: boolean | null;
@@ -67,8 +67,7 @@ export const useForm = <T>(initialValues: T): [T, Fields<T>] => {
   return [values, fields];
 };
 
-export const fieldTheme = {
-  ...defaultFieldTheme,
+export const fieldTheme: FieldTheme = {
   field: "form-group",
   input: "form-control",
   inputSuccess: "is-valid",
@@ -79,34 +78,34 @@ export const fieldTheme = {
   help: "form-text text-muted"
 };
 
-export const checkboxTheme = {
-  ...defaultFieldTheme,
+export const checkboxTheme: FieldTheme = {
+  ...fieldTheme,
   field: "form-check",
   fieldInline: "form-check-inline",
   input: "form-check-input",
   label: "form-check-label"
 };
 
-export const selectTheme = {
-  ...defaultFieldTheme,
+export const selectTheme: FieldTheme = {
+  ...fieldTheme,
   input: "custom-select"
 };
 
-export const fileInputTheme = {
-  ...defaultFieldTheme,
+export const fileInputTheme: FieldTheme = {
+  ...fieldTheme,
   field: "custom-file mb-3",
   input: "custom-file-input",
   label: "custom-file-label"
 };
 
-export const toggleButtonTheme = {
-  ...defaultFieldTheme,
+export const toggleButtonTheme: FieldTheme = {
+  ...fieldTheme,
   field: "custom-control custom-switch",
   input: "custom-control-input",
   label: "custom-control-label"
 };
 
-export const theme = {
+export const theme: Theme = {
   input: fieldTheme,
   dateInput: fieldTheme,
   dateTimeInput: fieldTheme,

--- a/examples/app/src/helpers.ts
+++ b/examples/app/src/helpers.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Theme } from "react-baseline-inputs";
+import { Theme, defaultConfig, defaultTheme } from "react-baseline-inputs";
 
 export interface Values {
   checkbox: boolean | null;
@@ -67,7 +67,8 @@ export const useForm = <T>(initialValues: T): [T, Fields<T>] => {
   return [values, fields];
 };
 
-export const theme: Theme = {
+export const fieldConfig = {
+  ...defaultTheme,
   field: "form-group",
   input: "form-control",
   inputSuccess: "is-valid",
@@ -78,31 +79,46 @@ export const theme: Theme = {
   help: "form-text text-muted"
 };
 
-export const selectTheme: Theme = {
-  ...theme,
-  input: "custom-select"
-};
-
-export const fileTheme: Theme = {
-  ...theme,
-  field: "custom-file mb-3",
-  input: "custom-file-input",
-  label: "custom-file-label"
-};
-
-export const checkboxTheme: Theme = {
-  ...theme,
+export const checkboxConfig = {
+  ...defaultTheme,
   field: "form-check",
   fieldInline: "form-check-inline",
   input: "form-check-input",
   label: "form-check-label"
 };
 
-export const toggleTheme: Theme = {
-  ...theme,
+export const selectConfig = {
+  ...defaultTheme,
+  input: "custom-select"
+};
+
+export const fileInputConfig = {
+  ...defaultTheme,
+  field: "custom-file mb-3",
+  input: "custom-file-input",
+  label: "custom-file-label"
+};
+
+export const toggleButtonConfig = {
+  ...defaultTheme,
   field: "custom-control custom-switch",
   input: "custom-control-input",
   label: "custom-control-label"
+};
+
+export const config = {
+  input: fieldConfig,
+  dateInput: fieldConfig,
+  dateTimeInput: fieldConfig,
+  field: fieldConfig,
+  floatInput: fieldConfig,
+  integerInput: fieldConfig,
+  radioGroup: checkboxConfig,
+  textarea: fieldConfig,
+  select: selectConfig,
+  fileInput: fileInputConfig,
+  checkbox: checkboxConfig,
+  toggleButton: toggleButtonConfig
 };
 
 export const telephoneMask = [

--- a/packages/formik-inputs/src/components.tsx
+++ b/packages/formik-inputs/src/components.tsx
@@ -15,7 +15,7 @@ import {
   Select as BSelect,
   TextArea as BTextArea,
   MaskedInput as BMaskedInput,
-  ToggleButton as BToggleButton
+  ToggleButton as BToggleButton,
   ThemeProvider
 } from "react-baseline-inputs";
 import {

--- a/packages/formik-inputs/src/components.tsx
+++ b/packages/formik-inputs/src/components.tsx
@@ -15,8 +15,7 @@ import {
   Select as BSelect,
   TextArea as BTextArea,
   MaskedInput as BMaskedInput,
-  ToggleButton as BToggleButton,
-  ThemeProvider
+  ToggleButton as BToggleButton
 } from "react-baseline-inputs";
 import {
   CheckboxListProps,
@@ -95,5 +94,3 @@ export const MaskedInput: React.FC<MaskedInputProps> = props => (
 export const ToggleButton: React.FC<ToggleButtonProps> = props => (
   <BToggleButton {...useField(props)} />
 );
-
-export { ThemeProvider };

--- a/packages/formik-inputs/src/components.tsx
+++ b/packages/formik-inputs/src/components.tsx
@@ -16,6 +16,7 @@ import {
   TextArea as BTextArea,
   MaskedInput as BMaskedInput,
   ToggleButton as BToggleButton
+  ThemeProvider
 } from "react-baseline-inputs";
 import {
   CheckboxListProps,
@@ -94,3 +95,5 @@ export const MaskedInput: React.FC<MaskedInputProps> = props => (
 export const ToggleButton: React.FC<ToggleButtonProps> = props => (
   <BToggleButton {...useField(props)} />
 );
+
+export { ThemeProvider };

--- a/packages/formik-inputs/src/index.ts
+++ b/packages/formik-inputs/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components";
 export * from "./types";
 export * from "./useField";
+export { Theme, FieldTheme, ThemeProvider } from "react-baseline-inputs";

--- a/packages/formik-inputs/test/index.test.ts
+++ b/packages/formik-inputs/test/index.test.ts
@@ -16,6 +16,7 @@ test("exports", () => {
     "RadioGroup",
     "Select",
     "TextArea",
+    "ThemeProvider",
     "ToggleButton",
     "useField"
   ]);

--- a/packages/react-baseline-inputs/src/Checkbox.tsx
+++ b/packages/react-baseline-inputs/src/Checkbox.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { CheckboxProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { CheckboxProps } from "./types";
 export const Checkbox: React.FC<CheckboxProps> = ({
   onChange,
   value,
+  theme = useTheme("checkbox"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -20,6 +22,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 
   return (
     <Field
+      theme={theme}
       labelPosition="after"
       render={inputProps => (
         <input

--- a/packages/react-baseline-inputs/src/Checkbox.tsx
+++ b/packages/react-baseline-inputs/src/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { CheckboxProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/CheckboxList.tsx
+++ b/packages/react-baseline-inputs/src/CheckboxList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { CheckboxListProps, OptionProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const getCheckboxProps = (option: OptionProps | string) => {
   if (typeof option === "string") {

--- a/packages/react-baseline-inputs/src/CheckboxList.tsx
+++ b/packages/react-baseline-inputs/src/CheckboxList.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { CheckboxListProps, OptionProps } from "./types";
+import { useTheme } from "./config";
 
 const getCheckboxProps = (option: OptionProps | string) => {
   if (typeof option === "string") {
@@ -21,6 +22,7 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
   value,
   onChange,
   options = [],
+  theme = useTheme("checkbox"),
   ...props
 }) => {
   const values = value || [];
@@ -44,6 +46,7 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
 
         return (
           <Field
+            theme={theme}
             key={checkbox.key}
             label={checkbox.label}
             labelPosition="after"

--- a/packages/react-baseline-inputs/src/DateInput.tsx
+++ b/packages/react-baseline-inputs/src/DateInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { DateInputProps } from "./types";
+import { useTheme } from "./config";
 
 const parse = (value: string): string | null => {
   const date = new Date(value);
@@ -17,6 +18,7 @@ const parse = (value: string): string | null => {
 export const DateInput: React.FC<DateInputProps> = ({
   value,
   onChange,
+  theme = useTheme("dateInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -26,6 +28,7 @@ export const DateInput: React.FC<DateInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input
           type="date"

--- a/packages/react-baseline-inputs/src/DateInput.tsx
+++ b/packages/react-baseline-inputs/src/DateInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { DateInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const parse = (value: string): string | null => {
   const date = new Date(value);

--- a/packages/react-baseline-inputs/src/DateTimeInput.tsx
+++ b/packages/react-baseline-inputs/src/DateTimeInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { DateTimeInputProps } from "./types";
+import { useTheme } from "./config";
 
 const format = (value: string | null): string => {
   return value ? value.substring(0, 16) : "";
@@ -21,6 +22,7 @@ const parse = (value: string): string | null => {
 export const DateTimeInput: React.FC<DateTimeInputProps> = ({
   value,
   onChange,
+  theme = useTheme("dateTimeInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -30,6 +32,7 @@ export const DateTimeInput: React.FC<DateTimeInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input
           type="datetime-local"

--- a/packages/react-baseline-inputs/src/DateTimeInput.tsx
+++ b/packages/react-baseline-inputs/src/DateTimeInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { DateTimeInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const format = (value: string | null): string => {
   return value ? value.substring(0, 16) : "";

--- a/packages/react-baseline-inputs/src/Field.tsx
+++ b/packages/react-baseline-inputs/src/Field.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { FieldProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const generateUniqueId = (() => {
   let previousId = 0;

--- a/packages/react-baseline-inputs/src/Field.tsx
+++ b/packages/react-baseline-inputs/src/Field.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { FieldProps } from "./types";
-import { defaultTheme } from "./defaultTheme";
+import { useTheme } from "./config";
 
 const generateUniqueId = (() => {
   let previousId = 0;
@@ -34,7 +34,7 @@ export function Field<T extends FieldProps>({
   large,
   small,
   wrapper = true,
-  theme = defaultTheme,
+  theme = useTheme("field"),
   disabled,
   ...props
 }: T) {

--- a/packages/react-baseline-inputs/src/FileInput.tsx
+++ b/packages/react-baseline-inputs/src/FileInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FileInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input type="file" />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/FileInput.tsx
+++ b/packages/react-baseline-inputs/src/FileInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FileInputProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input type="file" />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { FileInputProps } from "./types";
 export const FileInput: React.FC<FileInputProps> = ({
   onChange,
   value: _value,
+  theme = useTheme("fileInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -20,6 +22,7 @@ export const FileInput: React.FC<FileInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input type="file" onChange={handleChange} {...inputProps} />
       )}

--- a/packages/react-baseline-inputs/src/FileListInput.tsx
+++ b/packages/react-baseline-inputs/src/FileListInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FileListInputProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input type="file" />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { FileListInputProps } from "./types";
 export const FileListInput: React.FC<FileListInputProps> = ({
   onChange,
   value: _value,
+  theme = useTheme("fileInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -20,6 +22,7 @@ export const FileListInput: React.FC<FileListInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input type="file" onChange={handleChange} multiple {...inputProps} />
       )}

--- a/packages/react-baseline-inputs/src/FileListInput.tsx
+++ b/packages/react-baseline-inputs/src/FileListInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FileListInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input type="file" />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/FloatInput.tsx
+++ b/packages/react-baseline-inputs/src/FloatInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FloatInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input type="number" />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/FloatInput.tsx
+++ b/packages/react-baseline-inputs/src/FloatInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { FloatInputProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input type="number" />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { FloatInputProps } from "./types";
 export const FloatInput: React.FC<FloatInputProps> = ({
   value,
   onChange,
+  theme = useTheme("floatInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -23,6 +25,7 @@ export const FloatInput: React.FC<FloatInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input
           type="number"

--- a/packages/react-baseline-inputs/src/Input.tsx
+++ b/packages/react-baseline-inputs/src/Input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { InputProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input />`, but with the following benefits:
@@ -9,7 +10,12 @@ import { InputProps } from "./types";
  *   * It defaults to `type="text"`.
  *   * It emits a `null` value to the `onChange` handler when the input is empty.
  */
-export const Input: React.FC<InputProps> = ({ value, onChange, ...props }) => {
+export const Input: React.FC<InputProps> = ({
+  value,
+  onChange,
+  theme = useTheme("input"),
+  ...props
+}) => {
   const handleChange = React.useCallback(
     event => onChange(event.target.value || null),
     [onChange]
@@ -17,6 +23,7 @@ export const Input: React.FC<InputProps> = ({ value, onChange, ...props }) => {
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input
           type="text"

--- a/packages/react-baseline-inputs/src/Input.tsx
+++ b/packages/react-baseline-inputs/src/Input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { InputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/IntegerInput.tsx
+++ b/packages/react-baseline-inputs/src/IntegerInput.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { IntegerInputProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<input type="number" />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { IntegerInputProps } from "./types";
 export const IntegerInput: React.FC<IntegerInputProps> = ({
   value,
   onChange,
+  theme = useTheme("integerInput"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -23,6 +25,7 @@ export const IntegerInput: React.FC<IntegerInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <input
           type="number"

--- a/packages/react-baseline-inputs/src/IntegerInput.tsx
+++ b/packages/react-baseline-inputs/src/IntegerInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { IntegerInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<input type="number" />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/MaskedInput.tsx
+++ b/packages/react-baseline-inputs/src/MaskedInput.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 import { default as TextMask } from "react-text-mask";
 import { Field } from "./Field";
 import { MaskedInputProps } from "./types";
+import { useTheme } from "./config";
 
 export const MaskedInput: React.FC<MaskedInputProps> = ({
   value,
   onChange,
+  theme = useTheme("input"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -15,6 +17,7 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <TextMask {...inputProps} value={value || ""} onChange={handleChange} />
       )}

--- a/packages/react-baseline-inputs/src/MaskedInput.tsx
+++ b/packages/react-baseline-inputs/src/MaskedInput.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { default as TextMask } from "react-text-mask";
 import { Field } from "./Field";
 import { MaskedInputProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 export const MaskedInput: React.FC<MaskedInputProps> = ({
   value,

--- a/packages/react-baseline-inputs/src/RadioGroup.tsx
+++ b/packages/react-baseline-inputs/src/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { RadioGroupProps, OptionProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const getRadioProps = (option: OptionProps | string) => {
   if (typeof option === "string") {

--- a/packages/react-baseline-inputs/src/RadioGroup.tsx
+++ b/packages/react-baseline-inputs/src/RadioGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { RadioGroupProps, OptionProps } from "./types";
+import { useTheme } from "./config";
 
 const getRadioProps = (option: OptionProps | string) => {
   if (typeof option === "string") {
@@ -17,6 +18,7 @@ const getRadioProps = (option: OptionProps | string) => {
 export const RadioGroup: React.FC<RadioGroupProps> = ({
   value,
   onChange,
+  theme = useTheme("radioGroup"),
   options = [],
   ...props
 }) => {
@@ -32,6 +34,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
 
         return (
           <Field
+            theme={theme}
             key={radio.key}
             label={radio.label}
             labelPosition="after"

--- a/packages/react-baseline-inputs/src/Select.tsx
+++ b/packages/react-baseline-inputs/src/Select.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { SelectProps, OptionProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 const getOptionProps = (option: OptionProps | string) => {
   if (typeof option === "string") {

--- a/packages/react-baseline-inputs/src/Select.tsx
+++ b/packages/react-baseline-inputs/src/Select.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { SelectProps, OptionProps } from "./types";
+import { useTheme } from "./config";
 
 const getOptionProps = (option: OptionProps | string) => {
   if (typeof option === "string") {
@@ -23,6 +24,7 @@ export const Select: React.FC<SelectProps> = ({
   options = [],
   placeholder,
   value,
+  theme = useTheme("select"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -32,6 +34,7 @@ export const Select: React.FC<SelectProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <select
           value={value === null ? "" : value}

--- a/packages/react-baseline-inputs/src/TextArea.tsx
+++ b/packages/react-baseline-inputs/src/TextArea.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { TextAreaProps } from "./types";
+import { useTheme } from "./config";
 
 /**
  * An HTML `<textarea />`, but with the following benefits:
@@ -11,6 +12,7 @@ import { TextAreaProps } from "./types";
 export const TextArea: React.FC<TextAreaProps> = ({
   value,
   onChange,
+  theme = useTheme("textarea"),
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -20,6 +22,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
 
   return (
     <Field
+      theme={theme}
       render={inputProps => (
         <textarea value={value || ""} onChange={handleChange} {...inputProps} />
       )}

--- a/packages/react-baseline-inputs/src/TextArea.tsx
+++ b/packages/react-baseline-inputs/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { TextAreaProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 /**
  * An HTML `<textarea />`, but with the following benefits:

--- a/packages/react-baseline-inputs/src/ToggleButton.tsx
+++ b/packages/react-baseline-inputs/src/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { ToggleButtonProps } from "./types";
-import { useTheme } from "./config";
+import { useTheme } from "./theme";
 
 export const ToggleButton: React.FC<ToggleButtonProps> = ({
   value,

--- a/packages/react-baseline-inputs/src/ToggleButton.tsx
+++ b/packages/react-baseline-inputs/src/ToggleButton.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 import { Field } from "./Field";
 import { ToggleButtonProps } from "./types";
+import { useTheme } from "./config";
 
 export const ToggleButton: React.FC<ToggleButtonProps> = ({
   value,
   onChange,
+  theme = useTheme("toggleButton"),
   ...props
 }) => {
   const handleClick = React.useCallback(() => onChange(!value), [
@@ -14,6 +16,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
 
   return (
     <Field
+      theme={theme}
       labelPosition="after"
       render={inputProps => (
         <button

--- a/packages/react-baseline-inputs/src/config.ts
+++ b/packages/react-baseline-inputs/src/config.ts
@@ -1,6 +1,7 @@
-import { Theme } from "./types";
+import { Config } from "./types";
+import { useContext, createContext } from "react";
 
-export const defaultTheme: Theme = {
+export const defaultTheme = {
   field: "field",
   fieldInline: "field--inline",
   fieldSuccess: "field--success",
@@ -37,4 +38,27 @@ export const defaultTheme: Theme = {
   errorInline: "field__error--inline",
   errorSmall: "field__error--small",
   errorLarge: "field__error--large"
+};
+
+export const defaultConfig: Config = {
+  input: defaultTheme,
+  checkbox: defaultTheme,
+  dateInput: defaultTheme,
+  dateTimeInput: defaultTheme,
+  field: defaultTheme,
+  fileInput: defaultTheme,
+  floatInput: defaultTheme,
+  integerInput: defaultTheme,
+  radioGroup: defaultTheme,
+  select: defaultTheme,
+  textarea: defaultTheme,
+  toggleButton: defaultTheme
+};
+
+export const ThemeContext = createContext(defaultConfig);
+export const ThemeProvider = ThemeContext.Provider;
+
+export const useTheme = (element: keyof Config) => {
+  const config = useContext(ThemeContext);
+  return config[element];
 };

--- a/packages/react-baseline-inputs/src/index.ts
+++ b/packages/react-baseline-inputs/src/index.ts
@@ -13,5 +13,5 @@ export * from "./RadioGroup";
 export * from "./Select";
 export * from "./TextArea";
 export * from "./ToggleButton";
-export * from "./config";
+export * from "./theme";
 export * from "./types";

--- a/packages/react-baseline-inputs/src/index.ts
+++ b/packages/react-baseline-inputs/src/index.ts
@@ -13,5 +13,5 @@ export * from "./RadioGroup";
 export * from "./Select";
 export * from "./TextArea";
 export * from "./ToggleButton";
-export * from "./defaultTheme";
+export * from "./config";
 export * from "./types";

--- a/packages/react-baseline-inputs/src/theme.ts
+++ b/packages/react-baseline-inputs/src/theme.ts
@@ -1,7 +1,7 @@
-import { Config } from "./types";
+import { Theme, FieldTheme } from "./types";
 import { useContext, createContext } from "react";
 
-export const defaultFieldTheme = {
+export const defaultFieldTheme: FieldTheme = {
   field: "field",
   fieldInline: "field--inline",
   fieldSuccess: "field--success",
@@ -40,7 +40,7 @@ export const defaultFieldTheme = {
   errorLarge: "field__error--large"
 };
 
-export const defaultTheme: Config = {
+export const defaultTheme: Theme = {
   input: defaultFieldTheme,
   checkbox: defaultFieldTheme,
   dateInput: defaultFieldTheme,
@@ -58,7 +58,7 @@ export const defaultTheme: Config = {
 export const ThemeContext = createContext(defaultTheme);
 export const ThemeProvider = ThemeContext.Provider;
 
-export const useTheme = (element: keyof Config) => {
+export const useTheme = (element: keyof Theme) => {
   const config = useContext(ThemeContext);
   return config[element];
 };

--- a/packages/react-baseline-inputs/src/theme.ts
+++ b/packages/react-baseline-inputs/src/theme.ts
@@ -1,7 +1,7 @@
 import { Config } from "./types";
 import { useContext, createContext } from "react";
 
-export const defaultTheme = {
+export const defaultFieldTheme = {
   field: "field",
   fieldInline: "field--inline",
   fieldSuccess: "field--success",
@@ -40,22 +40,22 @@ export const defaultTheme = {
   errorLarge: "field__error--large"
 };
 
-export const defaultConfig: Config = {
-  input: defaultTheme,
-  checkbox: defaultTheme,
-  dateInput: defaultTheme,
-  dateTimeInput: defaultTheme,
-  field: defaultTheme,
-  fileInput: defaultTheme,
-  floatInput: defaultTheme,
-  integerInput: defaultTheme,
-  radioGroup: defaultTheme,
-  select: defaultTheme,
-  textarea: defaultTheme,
-  toggleButton: defaultTheme
+export const defaultTheme: Config = {
+  input: defaultFieldTheme,
+  checkbox: defaultFieldTheme,
+  dateInput: defaultFieldTheme,
+  dateTimeInput: defaultFieldTheme,
+  field: defaultFieldTheme,
+  fileInput: defaultFieldTheme,
+  floatInput: defaultFieldTheme,
+  integerInput: defaultFieldTheme,
+  radioGroup: defaultFieldTheme,
+  select: defaultFieldTheme,
+  textarea: defaultFieldTheme,
+  toggleButton: defaultFieldTheme
 };
 
-export const ThemeContext = createContext(defaultConfig);
+export const ThemeContext = createContext(defaultTheme);
 export const ThemeProvider = ThemeContext.Provider;
 
 export const useTheme = (element: keyof Config) => {

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { MaskedInputProps as TextMaskProps } from "react-text-mask";
 
-export interface Theme {
+export interface FieldTheme {
   field?: string | undefined;
   fieldInline?: string | undefined;
   fieldSuccess?: string | undefined;
@@ -40,19 +40,19 @@ export interface Theme {
   errorLarge?: string | undefined;
 }
 
-export interface Config {
-  input: Theme;
-  checkbox: Theme;
-  dateInput: Theme;
-  dateTimeInput: Theme;
-  field: Theme;
-  fileInput: Theme;
-  floatInput: Theme;
-  integerInput: Theme;
-  radioGroup: Theme;
-  select: Theme;
-  textarea: Theme;
-  toggleButton: Theme;
+export interface Theme {
+  input: FieldTheme;
+  checkbox: FieldTheme;
+  dateInput: FieldTheme;
+  dateTimeInput: FieldTheme;
+  field: FieldTheme;
+  fileInput: FieldTheme;
+  floatInput: FieldTheme;
+  integerInput: FieldTheme;
+  radioGroup: FieldTheme;
+  select: FieldTheme;
+  textarea: FieldTheme;
+  toggleButton: FieldTheme;
 }
 
 export interface FieldInputProps {
@@ -68,7 +68,7 @@ export interface FieldInputProps {
   label?: React.ReactNode;
   labelPosition?: "before" | "after";
   wrapper?: boolean;
-  theme?: Theme;
+  theme?: FieldTheme;
 }
 
 export interface OptionProps {

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -40,6 +40,21 @@ export interface Theme {
   errorLarge?: string | undefined;
 }
 
+export interface Config {
+  input: Theme;
+  checkbox: Theme;
+  dateInput: Theme;
+  dateTimeInput: Theme;
+  field: Theme;
+  fileInput: Theme;
+  floatInput: Theme;
+  integerInput: Theme;
+  radioGroup: Theme;
+  select: Theme;
+  textarea: Theme;
+  toggleButton: Theme;
+}
+
 export interface FieldInputProps {
   id?: string;
   inline?: boolean;

--- a/packages/react-baseline-inputs/test/index.test.ts
+++ b/packages/react-baseline-inputs/test/index.test.ts
@@ -19,7 +19,7 @@ test("exports", () => {
     "ThemeContext",
     "ThemeProvider",
     "ToggleButton",
-    "defaultConfig",
+    "defaultFieldTheme",
     "defaultTheme",
     "useTheme"
   ]);

--- a/packages/react-baseline-inputs/test/index.test.ts
+++ b/packages/react-baseline-inputs/test/index.test.ts
@@ -16,7 +16,11 @@ test("exports", () => {
     "RadioGroup",
     "Select",
     "TextArea",
+    "ThemeContext",
+    "ThemeProvider",
     "ToggleButton",
-    "defaultTheme"
+    "defaultConfig",
+    "defaultTheme",
+    "useTheme"
   ]);
 });


### PR DESCRIPTION
Adds theme support for each input with default fallbacks. Check out [BaselineInputs.tsx](https://github.com/promptworks/react-forms/blob/26f49296de14e41158210c628e647cfd34e99b91/examples/app/src/BaselineInputs.tsx) for sample usage with a `ThemeProvider` component.