### PR TITLE
Only pass the error prop when the field has been touched

### DIFF
--- a/packages/formik-inputs/src/useField.ts
+++ b/packages/formik-inputs/src/useField.ts
@@ -20,8 +20,8 @@ export const useField = <T extends FieldConfig>({
     onChange,
     onBlur: field.onBlur,
     value: field.value,
-    error: meta.error,
     touched: meta.touched,
+    error: meta.touched ? meta.error : undefined,
     ...props
   };
 };


### PR DESCRIPTION
This fixes a bug where if you touch *any* field on the form, validation errors will appear. Instead, you should only see validation errors/success on fields that you've touched.