### PR TITLE
fix: allow passed className in Field

### DIFF
--- a/packages/react-baseline-inputs/src/Field.tsx
+++ b/packages/react-baseline-inputs/src/Field.tsx
@@ -36,6 +36,7 @@ export function Field<T extends FieldProps>({
   wrapper = true,
   theme = useTheme("field"),
   disabled,
+  className,
   ...props
 }: T) {
   const fieldClassNames = [theme.field];
@@ -43,6 +44,10 @@ export function Field<T extends FieldProps>({
   const labelClassNames = [theme.label];
   const errorClassNames = [theme.error];
   const helpClassNames = [theme.help];
+
+  if (className) {
+    fieldClassNames.push(className);
+  }
 
   if (inline) {
     fieldClassNames.push(theme.fieldInline);

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -91,6 +91,7 @@ export interface ValueProps<V, C = V> {
 }
 
 export interface FieldProps extends FieldInputProps {
+  className?: string;
   render: (props: object) => React.ReactNode;
 }
 

--- a/packages/react-baseline-inputs/test/Field.test.tsx
+++ b/packages/react-baseline-inputs/test/Field.test.tsx
@@ -14,4 +14,10 @@ const setup = (props: Partial<FieldProps> = {}) =>
 
 describe("<Field />", () => {
   itBehavesLikeAField(setup);
+
+  it("accepts a passed className", () => {
+    const { container } = setup({ className: "sample" });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/react-baseline-inputs/test/__snapshots__/Field.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/Field.test.tsx.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Field /> accepts a passed className 1`] = `
+<div
+  class="field sample"
+>
+  <label
+    class="field__label"
+    for="field_11"
+  >
+    Jawn
+  </label>
+  <input
+    class="field__input"
+    id="field_11"
+  />
+</div>
+`;
+
 exports[`<Field /> renders 1`] = `
 <div
   class="field"


### PR DESCRIPTION
Noticed while integrating with Stackup that passing a `className` into a component would replace the `className` on `Field` rather than append to it.

This PR appends any passed `className` values to the `Field` container.