### PR TITLE
feat: wrap RadioGroup and CheckboxList with FieldSet by default

### DIFF
--- a/examples/app/src/BaselineInputs.tsx
+++ b/examples/app/src/BaselineInputs.tsx
@@ -6,7 +6,6 @@ import {
   CheckboxList,
   DateInput,
   DateTimeInput,
-  FieldSet,
   FileInput,
   FileListInput,
   FloatInput,
@@ -107,7 +106,7 @@ export const BaselineInputs = () => {
           <div className="row mt-4">
             <div className="col">
               <CheckboxList
-                title="Checkbox List"
+                legend="Checkbox List"
                 name="checkboxList"
                 options={[
                   { label: "Foo", value: "foo" },
@@ -120,7 +119,7 @@ export const BaselineInputs = () => {
 
             <div className="col">
               <RadioGroup
-                title="Radio Group"
+                legend="Radio Group"
                 name="radioGroup"
                 options={[
                   { label: "Foo", value: "foo" },

--- a/examples/app/src/BaselineInputs.tsx
+++ b/examples/app/src/BaselineInputs.tsx
@@ -106,31 +106,29 @@ export const BaselineInputs = () => {
 
           <div className="row mt-4">
             <div className="col">
-              <FieldSet legend="Checkbox List">
-                <CheckboxList
-                  name="checkboxList"
-                  options={[
-                    { label: "Foo", value: "foo" },
-                    { label: "Bar", value: "bar" },
-                    { label: "Disabled", value: "buzz", disabled: true }
-                  ]}
-                  {...fields.checkboxList}
-                />
-              </FieldSet>
+              <CheckboxList
+                title="Checkbox List"
+                name="checkboxList"
+                options={[
+                  { label: "Foo", value: "foo" },
+                  { label: "Bar", value: "bar" },
+                  { label: "Disabled", value: "buzz", disabled: true }
+                ]}
+                {...fields.checkboxList}
+              />
             </div>
 
             <div className="col">
-              <FieldSet legend="Radio Group">
-                <RadioGroup
-                  name="radioGroup"
-                  options={[
-                    { label: "Foo", value: "foo" },
-                    { label: "Bar", value: "bar" },
-                    { label: "Disabled", value: "buzz", disabled: true }
-                  ]}
-                  {...fields.radioGroup}
-                />
-              </FieldSet>
+              <RadioGroup
+                title="Radio Group"
+                name="radioGroup"
+                options={[
+                  { label: "Foo", value: "foo" },
+                  { label: "Bar", value: "bar" },
+                  { label: "Disabled", value: "buzz", disabled: true }
+                ]}
+                {...fields.radioGroup}
+              />
             </div>
           </div>
 

--- a/examples/app/src/FormikInputs.tsx
+++ b/examples/app/src/FormikInputs.tsx
@@ -7,7 +7,6 @@ import {
   CheckboxList,
   DateInput,
   DateTimeInput,
-  FieldSet,
   FileInput,
   FileListInput,
   FloatInput,
@@ -106,7 +105,7 @@ export const FormikInputs = () => {
             <div className="row mt-4">
               <div className="col">
                 <CheckboxList
-                  title="Checkbox List"
+                  legend="Checkbox List"
                   name="checkboxList"
                   options={[
                     { label: "Foo", value: "foo" },
@@ -118,7 +117,7 @@ export const FormikInputs = () => {
 
               <div className="col">
                 <RadioGroup
-                  title="Radio Group"
+                  legend="Radio Group"
                   name="radioGroup"
                   options={[
                     { label: "Foo", value: "foo" },

--- a/examples/app/src/FormikInputs.tsx
+++ b/examples/app/src/FormikInputs.tsx
@@ -105,29 +105,27 @@ export const FormikInputs = () => {
 
             <div className="row mt-4">
               <div className="col">
-                <FieldSet legend="Checkbox List">
-                  <CheckboxList
-                    name="checkboxList"
-                    options={[
-                      { label: "Foo", value: "foo" },
-                      { label: "Bar", value: "bar" },
-                      { label: "Disabled", value: "buzz", disabled: true }
-                    ]}
-                  />
-                </FieldSet>
+                <CheckboxList
+                  title="Checkbox List"
+                  name="checkboxList"
+                  options={[
+                    { label: "Foo", value: "foo" },
+                    { label: "Bar", value: "bar" },
+                    { label: "Disabled", value: "buzz", disabled: true }
+                  ]}
+                />
               </div>
 
               <div className="col">
-                <FieldSet legend="Radio Group">
-                  <RadioGroup
-                    name="radioGroup"
-                    options={[
-                      { label: "Foo", value: "foo" },
-                      { label: "Bar", value: "bar" },
-                      { label: "Disabled", value: "buzz", disabled: true }
-                    ]}
-                  />
-                </FieldSet>
+                <RadioGroup
+                  title="Radio Group"
+                  name="radioGroup"
+                  options={[
+                    { label: "Foo", value: "foo" },
+                    { label: "Bar", value: "bar" },
+                    { label: "Disabled", value: "buzz", disabled: true }
+                  ]}
+                />
               </div>
             </div>
 

--- a/packages/react-baseline-inputs/src/CheckboxList.tsx
+++ b/packages/react-baseline-inputs/src/CheckboxList.tsx
@@ -24,7 +24,7 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
   onChange,
   options = [],
   theme = useTheme("checkbox"),
-  title,
+  legend,
   wrapper = true,
   error,
   touched,
@@ -45,7 +45,7 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
   );
 
   const [Wrapper, wrapperProps] = wrapper
-    ? [FieldSet, { legend: title, error, touched }]
+    ? [FieldSet, { legend, error, touched }]
     : [React.Fragment, {}];
 
   return (

--- a/packages/react-baseline-inputs/src/CheckboxList.tsx
+++ b/packages/react-baseline-inputs/src/CheckboxList.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Field } from "./Field";
+import { FieldSet } from "./FieldSet";
 import { CheckboxListProps, OptionProps } from "./types";
 import { useTheme } from "./theme";
 
@@ -23,6 +24,10 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
   onChange,
   options = [],
   theme = useTheme("checkbox"),
+  title,
+  wrapper = true,
+  error,
+  touched,
   ...props
 }) => {
   const values = value || [];
@@ -39,8 +44,12 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
     [onChange, value]
   );
 
+  const [Wrapper, wrapperProps] = wrapper
+    ? [FieldSet, { legend: title, error, touched }]
+    : [React.Fragment, {}];
+
   return (
-    <React.Fragment>
+    <Wrapper {...wrapperProps}>
       {options.map(option => {
         const checkbox = getCheckboxProps(option);
 
@@ -64,6 +73,6 @@ export const CheckboxList: React.FC<CheckboxListProps> = ({
           />
         );
       })}
-    </React.Fragment>
+    </Wrapper>
   );
 };

--- a/packages/react-baseline-inputs/src/FieldSet.tsx
+++ b/packages/react-baseline-inputs/src/FieldSet.tsx
@@ -10,9 +10,9 @@ export const FieldSet: React.FC<FieldSetProps> = ({
   children,
   className,
   theme = useTheme("fieldSet"),
-  success,
   touched,
   error,
+  success = touched && !error,
   large,
   small
 }) => {

--- a/packages/react-baseline-inputs/src/FieldSet.tsx
+++ b/packages/react-baseline-inputs/src/FieldSet.tsx
@@ -14,7 +14,8 @@ export const FieldSet: React.FC<FieldSetProps> = ({
   error,
   success = touched && !error,
   large,
-  small
+  small,
+  wrapper = true
 }) => {
   const fieldSetTheme = theme as FieldSetTheme;
   const fieldSetClassNames = [fieldSetTheme.fieldSet];
@@ -57,13 +58,13 @@ export const FieldSet: React.FC<FieldSetProps> = ({
 
   const errorLabelId = `${id}_error`;
 
-  return (
+  return wrapper ? (
     <fieldset
       id={id}
       aria-describedby={error ? errorLabelId : undefined}
       className={join(fieldSetClassNames)}
     >
-      <legend className={join(legendClassNames)}>{legend}</legend>
+      {legend && <legend className={join(legendClassNames)}>{legend}</legend>}
 
       {help && <p className={join(helpClassNames)}>{help}</p>}
 
@@ -75,5 +76,7 @@ export const FieldSet: React.FC<FieldSetProps> = ({
         </span>
       )}
     </fieldset>
+  ) : (
+    <React.Fragment>{children}</React.Fragment>
   );
 };

--- a/packages/react-baseline-inputs/src/RadioGroup.tsx
+++ b/packages/react-baseline-inputs/src/RadioGroup.tsx
@@ -21,7 +21,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   onChange,
   theme = useTheme("radioGroup"),
   options = [],
-  title,
+  legend,
   wrapper = true,
   error,
   touched,
@@ -33,7 +33,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   );
 
   const [Wrapper, wrapperProps] = wrapper
-    ? [FieldSet, { legend: title, error, touched }]
+    ? [FieldSet, { legend, error, touched }]
     : [React.Fragment, {}];
 
   return (

--- a/packages/react-baseline-inputs/src/RadioGroup.tsx
+++ b/packages/react-baseline-inputs/src/RadioGroup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Field } from "./Field";
+import { FieldSet } from "./FieldSet";
 import { RadioGroupProps, OptionProps } from "./types";
 import { useTheme } from "./theme";
 
@@ -20,6 +21,10 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
   onChange,
   theme = useTheme("radioGroup"),
   options = [],
+  title,
+  wrapper = true,
+  error,
+  touched,
   ...props
 }) => {
   const handleChange = React.useCallback(
@@ -27,8 +32,12 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
     [onChange]
   );
 
+  const [Wrapper, wrapperProps] = wrapper
+    ? [FieldSet, { legend: title, error, touched }]
+    : [React.Fragment, {}];
+
   return (
-    <React.Fragment>
+    <Wrapper {...wrapperProps}>
       {options.map(option => {
         const radio = getRadioProps(option);
 
@@ -52,6 +61,6 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
           />
         );
       })}
-    </React.Fragment>
+    </Wrapper>
   );
 };

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -180,7 +180,6 @@ export type MaskedInputProps = FieldInputProps &
   OmitConflicts<TextMaskProps> &
   ValueProps<string | null>;
 
-// todo: see if we need fieldinputprops
 export type RadioGroupProps = FieldInputProps &
   FieldSetProps &
   HTMLProps<HTMLInputElement> &

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -124,12 +124,18 @@ export interface FieldSetProps extends HTMLProps<HTMLFieldSetElement> {
   legend?: React.ReactNode;
   help?: string;
   className?: string;
-  error?: string;
+  error?: React.ReactNode;
   theme?: FieldSetTheme;
   large?: boolean;
   small?: boolean;
   success?: boolean;
   touched?: boolean;
+}
+
+export interface ToggleGroupProps {
+  title?: string;
+  wrapper?: boolean;
+  options?: Array<OptionProps | string>;
 }
 
 export type CheckboxProps = FieldInputProps &
@@ -138,9 +144,8 @@ export type CheckboxProps = FieldInputProps &
 
 export type CheckboxListProps = FieldInputProps &
   HTMLProps<HTMLInputElement> &
-  ValueProps<string[] | null> & {
-    options?: Array<OptionProps | string>;
-  };
+  ValueProps<string[] | null> &
+  ToggleGroupProps;
 
 export type DateInputProps = FieldInputProps &
   HTMLProps<HTMLInputElement> &
@@ -180,9 +185,8 @@ export type MaskedInputProps = FieldInputProps &
 
 export type RadioGroupProps = FieldInputProps &
   HTMLProps<HTMLInputElement> &
-  ValueProps<string | null> & {
-    options?: Array<OptionProps | string>;
-  };
+  ValueProps<string | null> &
+  ToggleGroupProps;
 
 export type SelectProps = FieldInputProps &
   HTMLProps<HTMLSelectElement> &

--- a/packages/react-baseline-inputs/src/types.ts
+++ b/packages/react-baseline-inputs/src/types.ts
@@ -122,7 +122,7 @@ export interface FieldProps extends FieldInputProps {
 
 export interface FieldSetProps extends HTMLProps<HTMLFieldSetElement> {
   legend?: React.ReactNode;
-  help?: string;
+  help?: React.ReactNode;
   className?: string;
   error?: React.ReactNode;
   theme?: FieldSetTheme;
@@ -130,12 +130,7 @@ export interface FieldSetProps extends HTMLProps<HTMLFieldSetElement> {
   small?: boolean;
   success?: boolean;
   touched?: boolean;
-}
-
-export interface ToggleGroupProps {
-  title?: string;
   wrapper?: boolean;
-  options?: Array<OptionProps | string>;
 }
 
 export type CheckboxProps = FieldInputProps &
@@ -143,9 +138,11 @@ export type CheckboxProps = FieldInputProps &
   ValueProps<boolean | null>;
 
 export type CheckboxListProps = FieldInputProps &
+  FieldSetProps &
   HTMLProps<HTMLInputElement> &
-  ValueProps<string[] | null> &
-  ToggleGroupProps;
+  ValueProps<string[] | null> & {
+    options?: Array<OptionProps | string>;
+  };
 
 export type DateInputProps = FieldInputProps &
   HTMLProps<HTMLInputElement> &
@@ -183,10 +180,13 @@ export type MaskedInputProps = FieldInputProps &
   OmitConflicts<TextMaskProps> &
   ValueProps<string | null>;
 
+// todo: see if we need fieldinputprops
 export type RadioGroupProps = FieldInputProps &
+  FieldSetProps &
   HTMLProps<HTMLInputElement> &
-  ValueProps<string | null> &
-  ToggleGroupProps;
+  ValueProps<string | null> & {
+    options?: Array<OptionProps | string>;
+  };
 
 export type SelectProps = FieldInputProps &
   HTMLProps<HTMLSelectElement> &

--- a/packages/react-baseline-inputs/test/CheckboxList.test.tsx
+++ b/packages/react-baseline-inputs/test/CheckboxList.test.tsx
@@ -60,4 +60,18 @@ describe("<CheckboxList />", () => {
       expect(onChange).toHaveBeenCalledWith([]);
     });
   });
+
+  describe("<fieldset>", () => {
+    const options = ["foo", "bar", "buzz"];
+
+    it("is wrapped in a <fieldset> by default", () => {
+      const { container } = setup({ options });
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it("can be rendered unwrapped", () => {
+      const { container } = setup({ options, wrapper: false });
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/react-baseline-inputs/test/CheckboxList.test.tsx
+++ b/packages/react-baseline-inputs/test/CheckboxList.test.tsx
@@ -18,7 +18,7 @@ const setup = (props: Partial<CheckboxListProps> = {}) =>
   );
 
 describe("<CheckboxList />", () => {
-  itBehavesLikeAField(setup, ["label", "wrapper", "id"]);
+  itBehavesLikeAField(setup, ["label", "id"]);
 
   test("adds a new value when checked", () => {
     const onChange = jest.fn();

--- a/packages/react-baseline-inputs/test/FieldSet.test.tsx
+++ b/packages/react-baseline-inputs/test/FieldSet.test.tsx
@@ -7,7 +7,7 @@ const setup = (props: Partial<FieldSetProps> = {}) =>
   render(<FieldSet legend="Jawn" {...props} />);
 
 describe("<FieldSet />", () => {
-  itBehavesLikeAField(setup, ["label", "wrapper", "inline"]);
+  itBehavesLikeAField(setup, ["label", "inline"]);
 
   it("accepts a passed className", () => {
     const { container } = setup({ className: "sample" });

--- a/packages/react-baseline-inputs/test/RadioGroup.test.tsx
+++ b/packages/react-baseline-inputs/test/RadioGroup.test.tsx
@@ -18,7 +18,7 @@ const setup = (props: Partial<RadioGroupProps> = {}) =>
   );
 
 describe("<RadioGroup />", () => {
-  itBehavesLikeAField(setup, ["label", "wrapper", "id"]);
+  itBehavesLikeAField(setup, ["label", "id"]);
 
   test("emits the value on change", () => {
     const onChange = jest.fn();

--- a/packages/react-baseline-inputs/test/RadioGroup.test.tsx
+++ b/packages/react-baseline-inputs/test/RadioGroup.test.tsx
@@ -46,4 +46,18 @@ describe("<RadioGroup />", () => {
       expect(onChange).toHaveBeenCalledWith("foo");
     });
   });
+
+  describe("<fieldset>", () => {
+    const options = ["foo", "bar", "buzz"];
+
+    it("is wrapped in a <fieldset> by default", () => {
+      const { container } = setup({ options });
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it("can be rendered unwrapped", () => {
+      const { container } = setup({ options, wrapper: false });
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/react-baseline-inputs/test/__snapshots__/CheckboxList.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/CheckboxList.test.tsx.snap
@@ -1,186 +1,641 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CheckboxList /> an array of strings as options accepts an array of strings as options 1`] = `
+exports[`<CheckboxList /> <fieldset> can be rendered unwrapped 1`] = `
 <div
   class="field"
 >
   <input
     class="field__input"
-    id="field_31"
+    id="field_57"
     type="checkbox"
     value="foo"
   />
   <label
     class="field__label"
-    for="field_31"
+    for="field_57"
   >
     foo
   </label>
 </div>
 `;
 
-exports[`<CheckboxList /> renders 1`] = `
-<div
-  class="field"
+exports[`<CheckboxList /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_53"
 >
-  <input
-    class="field__input"
-    id="field_1"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label"
-    for="field_1"
+  <div
+    class="field"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input"
+      id="field_54"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_54"
+    >
+      foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_55"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_55"
+    >
+      bar
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_56"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label"
+      for="field_56"
+    >
+      buzz
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`<CheckboxList /> an array of strings as options accepts an array of strings as options 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_41"
+>
+  <legend
+    class="fieldset__legend"
+  />
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_42"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_42"
+    >
+      foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_43"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_43"
+    >
+      bar
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_44"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label"
+      for="field_44"
+    >
+      buzz
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`<CheckboxList /> renders 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_1"
+>
+  <legend
+    class="fieldset__legend"
+  />
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_2"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_2"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_3"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_3"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_4"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_4"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with an error 1`] = `
-<div
-  class="field field--erroneous"
+<fieldset
+  aria-describedby="field_5_error"
+  class="fieldset fieldset--erroneous"
+  id="field_5"
 >
-  <input
-    aria-labelledby="field_4_label field_4_error"
-    class="field__input field__input--erroneous"
-    id="field_4"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend fieldset__legend--erroneous"
   />
-  <label
-    class="field__label field__label--erroneous"
-    for="field_4"
-    id="field_4_label"
+  <div
+    class="field"
   >
-    Foo
-  </label>
+    <input
+      class="field__input"
+      id="field_6"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_6"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_7"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_7"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_8"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_8"
+    >
+      Disabled
+    </label>
+  </div>
   <span
-    class="field__error"
-    id="field_4_error"
+    class="fieldset__error"
+    id="field_5_error"
     role="alert"
   >
     Oh no!
   </span>
-</div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with help 1`] = `
-<div
-  class="field"
+<fieldset
+  class="fieldset"
+  id="field_9"
 >
-  <input
-    class="field__input"
-    id="field_7"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label"
-    for="field_7"
+  <div
+    class="field"
   >
-    Foo
-    <span
-      class="field__help"
+    <input
+      class="field__input"
+      id="field_10"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_10"
     >
-      Good luck
-    </span>
-  </label>
-</div>
+      Foo
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_11"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_11"
+    >
+      Bar
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_12"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_12"
+    >
+      Disabled
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with inline 1`] = `
-<div
-  class="field field--inline"
+<fieldset
+  class="fieldset"
+  id="field_29"
 >
-  <input
-    class="field__input field__input--inline"
-    id="field_22"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--inline"
-    for="field_22"
+  <div
+    class="field field--inline"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--inline"
+      id="field_30"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--inline"
+      for="field_30"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--inline"
+  >
+    <input
+      class="field__input field__input--inline"
+      id="field_31"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--inline"
+      for="field_31"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--inline field--disabled"
+  >
+    <input
+      class="field__input field__input--inline field__input--disabled"
+      disabled=""
+      id="field_32"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--inline field__label--disabled"
+      for="field_32"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with large 1`] = `
-<div
-  class="field field--large"
+<fieldset
+  class="fieldset"
+  id="field_21"
 >
-  <input
-    class="field__input field__input--large"
-    id="field_16"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--large"
-    for="field_16"
+  <div
+    class="field field--large"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--large"
+      id="field_22"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--large"
+      for="field_22"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--large"
+  >
+    <input
+      class="field__input field__input--large"
+      id="field_23"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--large"
+      for="field_23"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--large field--disabled"
+  >
+    <input
+      class="field__input field__input--large field__input--disabled"
+      disabled=""
+      id="field_24"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--large field__label--disabled"
+      for="field_24"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with small 1`] = `
-<div
-  class="field field--small"
+<fieldset
+  class="fieldset"
+  id="field_25"
 >
-  <input
-    class="field__input field__input--small"
-    id="field_19"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--small"
-    for="field_19"
+  <div
+    class="field field--small"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--small"
+      id="field_26"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--small"
+      for="field_26"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--small"
+  >
+    <input
+      class="field__input field__input--small"
+      id="field_27"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--small"
+      for="field_27"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--small field--disabled"
+  >
+    <input
+      class="field__input field__input--small field__input--disabled"
+      disabled=""
+      id="field_28"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--small field__label--disabled"
+      for="field_28"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with success 1`] = `
-<div
-  class="field field--success"
+<fieldset
+  class="fieldset"
+  id="field_13"
 >
-  <input
-    class="field__input field__input--success"
-    id="field_10"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--success"
-    for="field_10"
+  <div
+    class="field field--success"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--success"
+      id="field_14"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--success"
+      for="field_14"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--success"
+  >
+    <input
+      class="field__input field__input--success"
+      id="field_15"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--success"
+      for="field_15"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--success field--disabled"
+  >
+    <input
+      class="field__input field__input--success field__input--disabled"
+      disabled=""
+      id="field_16"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--success field__label--disabled"
+      for="field_16"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<CheckboxList /> renders with touched 1`] = `
-<div
-  class="field field--touched field--success"
+<fieldset
+  class="fieldset fieldset--success fieldset--touched"
+  id="field_17"
 >
-  <input
-    class="field__input field__input--touched field__input--success"
-    id="field_13"
-    type="checkbox"
-    value="foo"
+  <legend
+    class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
   />
-  <label
-    class="field__label field__label--touched field__label--success"
-    for="field_13"
+  <div
+    class="field"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input"
+      id="field_18"
+      type="checkbox"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_18"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_19"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_19"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_20"
+      type="checkbox"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_20"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;

--- a/packages/react-baseline-inputs/test/__snapshots__/CheckboxList.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/CheckboxList.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`<CheckboxList /> <fieldset> can be rendered unwrapped 1`] = `
 >
   <input
     class="field__input"
-    id="field_57"
+    id="field_60"
     type="checkbox"
     value="foo"
   />
   <label
     class="field__label"
-    for="field_57"
+    for="field_60"
   >
     foo
   </label>
@@ -22,23 +22,20 @@ exports[`<CheckboxList /> <fieldset> can be rendered unwrapped 1`] = `
 exports[`<CheckboxList /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
 <fieldset
   class="fieldset"
-  id="field_53"
+  id="field_56"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_54"
+      id="field_57"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_54"
+      for="field_57"
     >
       foo
     </label>
@@ -48,13 +45,13 @@ exports[`<CheckboxList /> <fieldset> is wrapped in a <fieldset> by default 1`] =
   >
     <input
       class="field__input"
-      id="field_55"
+      id="field_58"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_55"
+      for="field_58"
     >
       bar
     </label>
@@ -64,13 +61,13 @@ exports[`<CheckboxList /> <fieldset> is wrapped in a <fieldset> by default 1`] =
   >
     <input
       class="field__input"
-      id="field_56"
+      id="field_59"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label"
-      for="field_56"
+      for="field_59"
     >
       buzz
     </label>
@@ -81,23 +78,20 @@ exports[`<CheckboxList /> <fieldset> is wrapped in a <fieldset> by default 1`] =
 exports[`<CheckboxList /> an array of strings as options accepts an array of strings as options 1`] = `
 <fieldset
   class="fieldset"
-  id="field_41"
+  id="field_44"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_42"
+      id="field_45"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_42"
+      for="field_45"
     >
       foo
     </label>
@@ -107,13 +101,13 @@ exports[`<CheckboxList /> an array of strings as options accepts an array of str
   >
     <input
       class="field__input"
-      id="field_43"
+      id="field_46"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_43"
+      for="field_46"
     >
       bar
     </label>
@@ -123,13 +117,13 @@ exports[`<CheckboxList /> an array of strings as options accepts an array of str
   >
     <input
       class="field__input"
-      id="field_44"
+      id="field_47"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label"
-      for="field_44"
+      for="field_47"
     >
       buzz
     </label>
@@ -142,9 +136,6 @@ exports[`<CheckboxList /> renders 1`] = `
   class="fieldset"
   id="field_1"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
@@ -199,25 +190,22 @@ exports[`<CheckboxList /> renders 1`] = `
 
 exports[`<CheckboxList /> renders with an error 1`] = `
 <fieldset
-  aria-describedby="field_5_error"
+  aria-describedby="field_8_error"
   class="fieldset fieldset--erroneous"
-  id="field_5"
+  id="field_8"
 >
-  <legend
-    class="fieldset__legend fieldset__legend--erroneous"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_6"
+      id="field_9"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_6"
+      for="field_9"
     >
       Foo
     </label>
@@ -227,13 +215,13 @@ exports[`<CheckboxList /> renders with an error 1`] = `
   >
     <input
       class="field__input"
-      id="field_7"
+      id="field_10"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_7"
+      for="field_10"
     >
       Bar
     </label>
@@ -244,20 +232,20 @@ exports[`<CheckboxList /> renders with an error 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_8"
+      id="field_11"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_8"
+      for="field_11"
     >
       Disabled
     </label>
   </div>
   <span
     class="fieldset__error"
-    id="field_5_error"
+    id="field_8_error"
     role="alert"
   >
     Oh no!
@@ -268,23 +256,20 @@ exports[`<CheckboxList /> renders with an error 1`] = `
 exports[`<CheckboxList /> renders with help 1`] = `
 <fieldset
   class="fieldset"
-  id="field_9"
+  id="field_12"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_10"
+      id="field_13"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_10"
+      for="field_13"
     >
       Foo
       <span
@@ -299,13 +284,13 @@ exports[`<CheckboxList /> renders with help 1`] = `
   >
     <input
       class="field__input"
-      id="field_11"
+      id="field_14"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_11"
+      for="field_14"
     >
       Bar
       <span
@@ -321,13 +306,13 @@ exports[`<CheckboxList /> renders with help 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_12"
+      id="field_15"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_12"
+      for="field_15"
     >
       Disabled
       <span
@@ -343,23 +328,20 @@ exports[`<CheckboxList /> renders with help 1`] = `
 exports[`<CheckboxList /> renders with inline 1`] = `
 <fieldset
   class="fieldset"
-  id="field_29"
+  id="field_32"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--inline"
   >
     <input
       class="field__input field__input--inline"
-      id="field_30"
+      id="field_33"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label field__label--inline"
-      for="field_30"
+      for="field_33"
     >
       Foo
     </label>
@@ -369,13 +351,13 @@ exports[`<CheckboxList /> renders with inline 1`] = `
   >
     <input
       class="field__input field__input--inline"
-      id="field_31"
+      id="field_34"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label field__label--inline"
-      for="field_31"
+      for="field_34"
     >
       Bar
     </label>
@@ -386,13 +368,13 @@ exports[`<CheckboxList /> renders with inline 1`] = `
     <input
       class="field__input field__input--inline field__input--disabled"
       disabled=""
-      id="field_32"
+      id="field_35"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--inline field__label--disabled"
-      for="field_32"
+      for="field_35"
     >
       Disabled
     </label>
@@ -403,23 +385,20 @@ exports[`<CheckboxList /> renders with inline 1`] = `
 exports[`<CheckboxList /> renders with large 1`] = `
 <fieldset
   class="fieldset"
-  id="field_21"
+  id="field_24"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--large"
   >
     <input
       class="field__input field__input--large"
-      id="field_22"
+      id="field_25"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label field__label--large"
-      for="field_22"
+      for="field_25"
     >
       Foo
     </label>
@@ -429,13 +408,13 @@ exports[`<CheckboxList /> renders with large 1`] = `
   >
     <input
       class="field__input field__input--large"
-      id="field_23"
+      id="field_26"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label field__label--large"
-      for="field_23"
+      for="field_26"
     >
       Bar
     </label>
@@ -446,13 +425,13 @@ exports[`<CheckboxList /> renders with large 1`] = `
     <input
       class="field__input field__input--large field__input--disabled"
       disabled=""
-      id="field_24"
+      id="field_27"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--large field__label--disabled"
-      for="field_24"
+      for="field_27"
     >
       Disabled
     </label>
@@ -463,23 +442,20 @@ exports[`<CheckboxList /> renders with large 1`] = `
 exports[`<CheckboxList /> renders with small 1`] = `
 <fieldset
   class="fieldset"
-  id="field_25"
+  id="field_28"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--small"
   >
     <input
       class="field__input field__input--small"
-      id="field_26"
+      id="field_29"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label field__label--small"
-      for="field_26"
+      for="field_29"
     >
       Foo
     </label>
@@ -489,13 +465,13 @@ exports[`<CheckboxList /> renders with small 1`] = `
   >
     <input
       class="field__input field__input--small"
-      id="field_27"
+      id="field_30"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label field__label--small"
-      for="field_27"
+      for="field_30"
     >
       Bar
     </label>
@@ -506,13 +482,13 @@ exports[`<CheckboxList /> renders with small 1`] = `
     <input
       class="field__input field__input--small field__input--disabled"
       disabled=""
-      id="field_28"
+      id="field_31"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--small field__label--disabled"
-      for="field_28"
+      for="field_31"
     >
       Disabled
     </label>
@@ -523,23 +499,20 @@ exports[`<CheckboxList /> renders with small 1`] = `
 exports[`<CheckboxList /> renders with success 1`] = `
 <fieldset
   class="fieldset"
-  id="field_13"
+  id="field_16"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--success"
   >
     <input
       class="field__input field__input--success"
-      id="field_14"
+      id="field_17"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label field__label--success"
-      for="field_14"
+      for="field_17"
     >
       Foo
     </label>
@@ -549,13 +522,13 @@ exports[`<CheckboxList /> renders with success 1`] = `
   >
     <input
       class="field__input field__input--success"
-      id="field_15"
+      id="field_18"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label field__label--success"
-      for="field_15"
+      for="field_18"
     >
       Bar
     </label>
@@ -566,13 +539,13 @@ exports[`<CheckboxList /> renders with success 1`] = `
     <input
       class="field__input field__input--success field__input--disabled"
       disabled=""
-      id="field_16"
+      id="field_19"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--success field__label--disabled"
-      for="field_16"
+      for="field_19"
     >
       Disabled
     </label>
@@ -583,23 +556,20 @@ exports[`<CheckboxList /> renders with success 1`] = `
 exports[`<CheckboxList /> renders with touched 1`] = `
 <fieldset
   class="fieldset fieldset--success fieldset--touched"
-  id="field_17"
+  id="field_20"
 >
-  <legend
-    class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_18"
+      id="field_21"
       type="checkbox"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_18"
+      for="field_21"
     >
       Foo
     </label>
@@ -609,13 +579,13 @@ exports[`<CheckboxList /> renders with touched 1`] = `
   >
     <input
       class="field__input"
-      id="field_19"
+      id="field_22"
       type="checkbox"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_19"
+      for="field_22"
     >
       Bar
     </label>
@@ -626,16 +596,35 @@ exports[`<CheckboxList /> renders with touched 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_20"
+      id="field_23"
       type="checkbox"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_20"
+      for="field_23"
     >
       Disabled
     </label>
   </div>
 </fieldset>
+`;
+
+exports[`<CheckboxList /> renders without a wrapper 1`] = `
+<div
+  class="field"
+>
+  <input
+    class="field__input"
+    id="field_5"
+    type="checkbox"
+    value="foo"
+  />
+  <label
+    class="field__label"
+    for="field_5"
+  >
+    Foo
+  </label>
+</div>
 `;

--- a/packages/react-baseline-inputs/test/__snapshots__/FieldSet.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/FieldSet.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<FieldSet /> accepts a passed className 1`] = `
 <fieldset
   class="fieldset sample"
-  id="field_8"
+  id="field_9"
 >
   <legend
     class="fieldset__legend"
@@ -41,9 +41,9 @@ exports[`<FieldSet /> renders with a custom ID 1`] = `
 
 exports[`<FieldSet /> renders with an error 1`] = `
 <fieldset
-  aria-describedby="field_2_error"
+  aria-describedby="field_3_error"
   class="fieldset fieldset--erroneous"
-  id="field_2"
+  id="field_3"
 >
   <legend
     class="fieldset__legend fieldset__legend--erroneous"
@@ -52,7 +52,7 @@ exports[`<FieldSet /> renders with an error 1`] = `
   </legend>
   <span
     class="fieldset__error"
-    id="field_2_error"
+    id="field_3_error"
     role="alert"
   >
     Oh no!
@@ -63,7 +63,7 @@ exports[`<FieldSet /> renders with an error 1`] = `
 exports[`<FieldSet /> renders with help 1`] = `
 <fieldset
   class="fieldset"
-  id="field_3"
+  id="field_4"
 >
   <legend
     class="fieldset__legend"
@@ -81,7 +81,7 @@ exports[`<FieldSet /> renders with help 1`] = `
 exports[`<FieldSet /> renders with large 1`] = `
 <fieldset
   class="fieldset fieldset--large"
-  id="field_6"
+  id="field_7"
 >
   <legend
     class="fieldset__legend fieldset__legend--large"
@@ -94,7 +94,7 @@ exports[`<FieldSet /> renders with large 1`] = `
 exports[`<FieldSet /> renders with small 1`] = `
 <fieldset
   class="fieldset fieldset--small"
-  id="field_7"
+  id="field_8"
 >
   <legend
     class="fieldset__legend fieldset__legend--small"
@@ -107,7 +107,7 @@ exports[`<FieldSet /> renders with small 1`] = `
 exports[`<FieldSet /> renders with success 1`] = `
 <fieldset
   class="fieldset fieldset--success"
-  id="field_4"
+  id="field_5"
 >
   <legend
     class="fieldset__legend fieldset__legend--success"
@@ -120,7 +120,7 @@ exports[`<FieldSet /> renders with success 1`] = `
 exports[`<FieldSet /> renders with touched 1`] = `
 <fieldset
   class="fieldset fieldset--success fieldset--touched"
-  id="field_5"
+  id="field_6"
 >
   <legend
     class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
@@ -129,3 +129,5 @@ exports[`<FieldSet /> renders with touched 1`] = `
   </legend>
 </fieldset>
 `;
+
+exports[`<FieldSet /> renders without a wrapper 1`] = `null`;

--- a/packages/react-baseline-inputs/test/__snapshots__/FieldSet.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/FieldSet.test.tsx.snap
@@ -119,11 +119,11 @@ exports[`<FieldSet /> renders with success 1`] = `
 
 exports[`<FieldSet /> renders with touched 1`] = `
 <fieldset
-  class="fieldset fieldset--touched"
+  class="fieldset fieldset--success fieldset--touched"
   id="field_5"
 >
   <legend
-    class="fieldset__legend fieldset__legend--touched"
+    class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
   >
     Jawn
   </legend>

--- a/packages/react-baseline-inputs/test/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,186 +1,641 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RadioGroup /> an array of strings as options accepts an array of strings as options 1`] = `
+exports[`<RadioGroup /> <fieldset> can be rendered unwrapped 1`] = `
 <div
   class="field"
 >
   <input
     class="field__input"
-    id="field_28"
+    id="field_49"
     type="radio"
     value="foo"
   />
   <label
     class="field__label"
-    for="field_28"
+    for="field_49"
   >
     foo
   </label>
 </div>
 `;
 
-exports[`<RadioGroup /> renders 1`] = `
-<div
-  class="field"
+exports[`<RadioGroup /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_45"
 >
-  <input
-    class="field__input"
-    id="field_1"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label"
-    for="field_1"
+  <div
+    class="field"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input"
+      id="field_46"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_46"
+    >
+      foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_47"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_47"
+    >
+      bar
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_48"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label"
+      for="field_48"
+    >
+      buzz
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`<RadioGroup /> an array of strings as options accepts an array of strings as options 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_37"
+>
+  <legend
+    class="fieldset__legend"
+  />
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_38"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_38"
+    >
+      foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_39"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_39"
+    >
+      bar
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_40"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label"
+      for="field_40"
+    >
+      buzz
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`<RadioGroup /> renders 1`] = `
+<fieldset
+  class="fieldset"
+  id="field_1"
+>
+  <legend
+    class="fieldset__legend"
+  />
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_2"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_2"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_3"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_3"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_4"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_4"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with an error 1`] = `
-<div
-  class="field field--erroneous"
+<fieldset
+  aria-describedby="field_5_error"
+  class="fieldset fieldset--erroneous"
+  id="field_5"
 >
-  <input
-    aria-labelledby="field_4_label field_4_error"
-    class="field__input field__input--erroneous"
-    id="field_4"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend fieldset__legend--erroneous"
   />
-  <label
-    class="field__label field__label--erroneous"
-    for="field_4"
-    id="field_4_label"
+  <div
+    class="field"
   >
-    Foo
-  </label>
+    <input
+      class="field__input"
+      id="field_6"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_6"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_7"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_7"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_8"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_8"
+    >
+      Disabled
+    </label>
+  </div>
   <span
-    class="field__error"
-    id="field_4_error"
+    class="fieldset__error"
+    id="field_5_error"
     role="alert"
   >
     Oh no!
   </span>
-</div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with help 1`] = `
-<div
-  class="field"
+<fieldset
+  class="fieldset"
+  id="field_9"
 >
-  <input
-    class="field__input"
-    id="field_7"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label"
-    for="field_7"
+  <div
+    class="field"
   >
-    Foo
-    <span
-      class="field__help"
+    <input
+      class="field__input"
+      id="field_10"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_10"
     >
-      Good luck
-    </span>
-  </label>
-</div>
+      Foo
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_11"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_11"
+    >
+      Bar
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_12"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_12"
+    >
+      Disabled
+      <span
+        class="field__help"
+      >
+        Good luck
+      </span>
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with inline 1`] = `
-<div
-  class="field field--inline"
+<fieldset
+  class="fieldset"
+  id="field_29"
 >
-  <input
-    class="field__input field__input--inline"
-    id="field_22"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--inline"
-    for="field_22"
+  <div
+    class="field field--inline"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--inline"
+      id="field_30"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--inline"
+      for="field_30"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--inline"
+  >
+    <input
+      class="field__input field__input--inline"
+      id="field_31"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--inline"
+      for="field_31"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--inline field--disabled"
+  >
+    <input
+      class="field__input field__input--inline field__input--disabled"
+      disabled=""
+      id="field_32"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--inline field__label--disabled"
+      for="field_32"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with large 1`] = `
-<div
-  class="field field--large"
+<fieldset
+  class="fieldset"
+  id="field_21"
 >
-  <input
-    class="field__input field__input--large"
-    id="field_16"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--large"
-    for="field_16"
+  <div
+    class="field field--large"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--large"
+      id="field_22"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--large"
+      for="field_22"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--large"
+  >
+    <input
+      class="field__input field__input--large"
+      id="field_23"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--large"
+      for="field_23"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--large field--disabled"
+  >
+    <input
+      class="field__input field__input--large field__input--disabled"
+      disabled=""
+      id="field_24"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--large field__label--disabled"
+      for="field_24"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with small 1`] = `
-<div
-  class="field field--small"
+<fieldset
+  class="fieldset"
+  id="field_25"
 >
-  <input
-    class="field__input field__input--small"
-    id="field_19"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--small"
-    for="field_19"
+  <div
+    class="field field--small"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--small"
+      id="field_26"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--small"
+      for="field_26"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--small"
+  >
+    <input
+      class="field__input field__input--small"
+      id="field_27"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--small"
+      for="field_27"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--small field--disabled"
+  >
+    <input
+      class="field__input field__input--small field__input--disabled"
+      disabled=""
+      id="field_28"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--small field__label--disabled"
+      for="field_28"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with success 1`] = `
-<div
-  class="field field--success"
+<fieldset
+  class="fieldset"
+  id="field_13"
 >
-  <input
-    class="field__input field__input--success"
-    id="field_10"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend"
   />
-  <label
-    class="field__label field__label--success"
-    for="field_10"
+  <div
+    class="field field--success"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input field__input--success"
+      id="field_14"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label field__label--success"
+      for="field_14"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field field--success"
+  >
+    <input
+      class="field__input field__input--success"
+      id="field_15"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label field__label--success"
+      for="field_15"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--success field--disabled"
+  >
+    <input
+      class="field__input field__input--success field__input--disabled"
+      disabled=""
+      id="field_16"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--success field__label--disabled"
+      for="field_16"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;
 
 exports[`<RadioGroup /> renders with touched 1`] = `
-<div
-  class="field field--touched field--success"
+<fieldset
+  class="fieldset fieldset--success fieldset--touched"
+  id="field_17"
 >
-  <input
-    class="field__input field__input--touched field__input--success"
-    id="field_13"
-    type="radio"
-    value="foo"
+  <legend
+    class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
   />
-  <label
-    class="field__label field__label--touched field__label--success"
-    for="field_13"
+  <div
+    class="field"
   >
-    Foo
-  </label>
-</div>
+    <input
+      class="field__input"
+      id="field_18"
+      type="radio"
+      value="foo"
+    />
+    <label
+      class="field__label"
+      for="field_18"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    class="field"
+  >
+    <input
+      class="field__input"
+      id="field_19"
+      type="radio"
+      value="bar"
+    />
+    <label
+      class="field__label"
+      for="field_19"
+    >
+      Bar
+    </label>
+  </div>
+  <div
+    class="field field--disabled"
+  >
+    <input
+      class="field__input field__input--disabled"
+      disabled=""
+      id="field_20"
+      type="radio"
+      value="buzz"
+    />
+    <label
+      class="field__label field__label--disabled"
+      for="field_20"
+    >
+      Disabled
+    </label>
+  </div>
+</fieldset>
 `;

--- a/packages/react-baseline-inputs/test/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/react-baseline-inputs/test/__snapshots__/RadioGroup.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`<RadioGroup /> <fieldset> can be rendered unwrapped 1`] = `
 >
   <input
     class="field__input"
-    id="field_49"
+    id="field_52"
     type="radio"
     value="foo"
   />
   <label
     class="field__label"
-    for="field_49"
+    for="field_52"
   >
     foo
   </label>
@@ -22,23 +22,20 @@ exports[`<RadioGroup /> <fieldset> can be rendered unwrapped 1`] = `
 exports[`<RadioGroup /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
 <fieldset
   class="fieldset"
-  id="field_45"
+  id="field_48"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_46"
+      id="field_49"
       type="radio"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_46"
+      for="field_49"
     >
       foo
     </label>
@@ -48,13 +45,13 @@ exports[`<RadioGroup /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
   >
     <input
       class="field__input"
-      id="field_47"
+      id="field_50"
       type="radio"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_47"
+      for="field_50"
     >
       bar
     </label>
@@ -64,13 +61,13 @@ exports[`<RadioGroup /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
   >
     <input
       class="field__input"
-      id="field_48"
+      id="field_51"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label"
-      for="field_48"
+      for="field_51"
     >
       buzz
     </label>
@@ -81,23 +78,20 @@ exports[`<RadioGroup /> <fieldset> is wrapped in a <fieldset> by default 1`] = `
 exports[`<RadioGroup /> an array of strings as options accepts an array of strings as options 1`] = `
 <fieldset
   class="fieldset"
-  id="field_37"
+  id="field_40"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_38"
+      id="field_41"
       type="radio"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_38"
+      for="field_41"
     >
       foo
     </label>
@@ -107,13 +101,13 @@ exports[`<RadioGroup /> an array of strings as options accepts an array of strin
   >
     <input
       class="field__input"
-      id="field_39"
+      id="field_42"
       type="radio"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_39"
+      for="field_42"
     >
       bar
     </label>
@@ -123,13 +117,13 @@ exports[`<RadioGroup /> an array of strings as options accepts an array of strin
   >
     <input
       class="field__input"
-      id="field_40"
+      id="field_43"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label"
-      for="field_40"
+      for="field_43"
     >
       buzz
     </label>
@@ -142,9 +136,6 @@ exports[`<RadioGroup /> renders 1`] = `
   class="fieldset"
   id="field_1"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
@@ -199,25 +190,22 @@ exports[`<RadioGroup /> renders 1`] = `
 
 exports[`<RadioGroup /> renders with an error 1`] = `
 <fieldset
-  aria-describedby="field_5_error"
+  aria-describedby="field_8_error"
   class="fieldset fieldset--erroneous"
-  id="field_5"
+  id="field_8"
 >
-  <legend
-    class="fieldset__legend fieldset__legend--erroneous"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_6"
+      id="field_9"
       type="radio"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_6"
+      for="field_9"
     >
       Foo
     </label>
@@ -227,13 +215,13 @@ exports[`<RadioGroup /> renders with an error 1`] = `
   >
     <input
       class="field__input"
-      id="field_7"
+      id="field_10"
       type="radio"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_7"
+      for="field_10"
     >
       Bar
     </label>
@@ -244,20 +232,20 @@ exports[`<RadioGroup /> renders with an error 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_8"
+      id="field_11"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_8"
+      for="field_11"
     >
       Disabled
     </label>
   </div>
   <span
     class="fieldset__error"
-    id="field_5_error"
+    id="field_8_error"
     role="alert"
   >
     Oh no!
@@ -268,23 +256,20 @@ exports[`<RadioGroup /> renders with an error 1`] = `
 exports[`<RadioGroup /> renders with help 1`] = `
 <fieldset
   class="fieldset"
-  id="field_9"
+  id="field_12"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_10"
+      id="field_13"
       type="radio"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_10"
+      for="field_13"
     >
       Foo
       <span
@@ -299,13 +284,13 @@ exports[`<RadioGroup /> renders with help 1`] = `
   >
     <input
       class="field__input"
-      id="field_11"
+      id="field_14"
       type="radio"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_11"
+      for="field_14"
     >
       Bar
       <span
@@ -321,13 +306,13 @@ exports[`<RadioGroup /> renders with help 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_12"
+      id="field_15"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_12"
+      for="field_15"
     >
       Disabled
       <span
@@ -343,23 +328,20 @@ exports[`<RadioGroup /> renders with help 1`] = `
 exports[`<RadioGroup /> renders with inline 1`] = `
 <fieldset
   class="fieldset"
-  id="field_29"
+  id="field_32"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--inline"
   >
     <input
       class="field__input field__input--inline"
-      id="field_30"
+      id="field_33"
       type="radio"
       value="foo"
     />
     <label
       class="field__label field__label--inline"
-      for="field_30"
+      for="field_33"
     >
       Foo
     </label>
@@ -369,13 +351,13 @@ exports[`<RadioGroup /> renders with inline 1`] = `
   >
     <input
       class="field__input field__input--inline"
-      id="field_31"
+      id="field_34"
       type="radio"
       value="bar"
     />
     <label
       class="field__label field__label--inline"
-      for="field_31"
+      for="field_34"
     >
       Bar
     </label>
@@ -386,13 +368,13 @@ exports[`<RadioGroup /> renders with inline 1`] = `
     <input
       class="field__input field__input--inline field__input--disabled"
       disabled=""
-      id="field_32"
+      id="field_35"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--inline field__label--disabled"
-      for="field_32"
+      for="field_35"
     >
       Disabled
     </label>
@@ -403,23 +385,20 @@ exports[`<RadioGroup /> renders with inline 1`] = `
 exports[`<RadioGroup /> renders with large 1`] = `
 <fieldset
   class="fieldset"
-  id="field_21"
+  id="field_24"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--large"
   >
     <input
       class="field__input field__input--large"
-      id="field_22"
+      id="field_25"
       type="radio"
       value="foo"
     />
     <label
       class="field__label field__label--large"
-      for="field_22"
+      for="field_25"
     >
       Foo
     </label>
@@ -429,13 +408,13 @@ exports[`<RadioGroup /> renders with large 1`] = `
   >
     <input
       class="field__input field__input--large"
-      id="field_23"
+      id="field_26"
       type="radio"
       value="bar"
     />
     <label
       class="field__label field__label--large"
-      for="field_23"
+      for="field_26"
     >
       Bar
     </label>
@@ -446,13 +425,13 @@ exports[`<RadioGroup /> renders with large 1`] = `
     <input
       class="field__input field__input--large field__input--disabled"
       disabled=""
-      id="field_24"
+      id="field_27"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--large field__label--disabled"
-      for="field_24"
+      for="field_27"
     >
       Disabled
     </label>
@@ -463,23 +442,20 @@ exports[`<RadioGroup /> renders with large 1`] = `
 exports[`<RadioGroup /> renders with small 1`] = `
 <fieldset
   class="fieldset"
-  id="field_25"
+  id="field_28"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--small"
   >
     <input
       class="field__input field__input--small"
-      id="field_26"
+      id="field_29"
       type="radio"
       value="foo"
     />
     <label
       class="field__label field__label--small"
-      for="field_26"
+      for="field_29"
     >
       Foo
     </label>
@@ -489,13 +465,13 @@ exports[`<RadioGroup /> renders with small 1`] = `
   >
     <input
       class="field__input field__input--small"
-      id="field_27"
+      id="field_30"
       type="radio"
       value="bar"
     />
     <label
       class="field__label field__label--small"
-      for="field_27"
+      for="field_30"
     >
       Bar
     </label>
@@ -506,13 +482,13 @@ exports[`<RadioGroup /> renders with small 1`] = `
     <input
       class="field__input field__input--small field__input--disabled"
       disabled=""
-      id="field_28"
+      id="field_31"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--small field__label--disabled"
-      for="field_28"
+      for="field_31"
     >
       Disabled
     </label>
@@ -523,23 +499,20 @@ exports[`<RadioGroup /> renders with small 1`] = `
 exports[`<RadioGroup /> renders with success 1`] = `
 <fieldset
   class="fieldset"
-  id="field_13"
+  id="field_16"
 >
-  <legend
-    class="fieldset__legend"
-  />
   <div
     class="field field--success"
   >
     <input
       class="field__input field__input--success"
-      id="field_14"
+      id="field_17"
       type="radio"
       value="foo"
     />
     <label
       class="field__label field__label--success"
-      for="field_14"
+      for="field_17"
     >
       Foo
     </label>
@@ -549,13 +522,13 @@ exports[`<RadioGroup /> renders with success 1`] = `
   >
     <input
       class="field__input field__input--success"
-      id="field_15"
+      id="field_18"
       type="radio"
       value="bar"
     />
     <label
       class="field__label field__label--success"
-      for="field_15"
+      for="field_18"
     >
       Bar
     </label>
@@ -566,13 +539,13 @@ exports[`<RadioGroup /> renders with success 1`] = `
     <input
       class="field__input field__input--success field__input--disabled"
       disabled=""
-      id="field_16"
+      id="field_19"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--success field__label--disabled"
-      for="field_16"
+      for="field_19"
     >
       Disabled
     </label>
@@ -583,23 +556,20 @@ exports[`<RadioGroup /> renders with success 1`] = `
 exports[`<RadioGroup /> renders with touched 1`] = `
 <fieldset
   class="fieldset fieldset--success fieldset--touched"
-  id="field_17"
+  id="field_20"
 >
-  <legend
-    class="fieldset__legend fieldset__legend--success fieldset__legend--touched"
-  />
   <div
     class="field"
   >
     <input
       class="field__input"
-      id="field_18"
+      id="field_21"
       type="radio"
       value="foo"
     />
     <label
       class="field__label"
-      for="field_18"
+      for="field_21"
     >
       Foo
     </label>
@@ -609,13 +579,13 @@ exports[`<RadioGroup /> renders with touched 1`] = `
   >
     <input
       class="field__input"
-      id="field_19"
+      id="field_22"
       type="radio"
       value="bar"
     />
     <label
       class="field__label"
-      for="field_19"
+      for="field_22"
     >
       Bar
     </label>
@@ -626,16 +596,35 @@ exports[`<RadioGroup /> renders with touched 1`] = `
     <input
       class="field__input field__input--disabled"
       disabled=""
-      id="field_20"
+      id="field_23"
       type="radio"
       value="buzz"
     />
     <label
       class="field__label field__label--disabled"
-      for="field_20"
+      for="field_23"
     >
       Disabled
     </label>
   </div>
 </fieldset>
+`;
+
+exports[`<RadioGroup /> renders without a wrapper 1`] = `
+<div
+  class="field"
+>
+  <input
+    class="field__input"
+    id="field_5"
+    type="radio"
+    value="foo"
+  />
+  <label
+    class="field__label"
+    for="field_5"
+  >
+    Foo
+  </label>
+</div>
 `;


### PR DESCRIPTION
- Wraps `RadioGroup` and `CheckboxList` with a `FieldSet` by default.
- You can optionally pass `wrapper={false}` to get the raw list wrapped in a `Fragment`.
- Supports `error` and `touched` via Formik context, and computes `success` based on those values.
